### PR TITLE
trim image

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,7 @@
 # Base ----------------------------------------
 matplotlib>=3.2.2
 numpy>=1.18.5
-opencv-python>=4.1.1
-Pillow>=7.1.2
+opencv-python-headless==4.10.0.84
 PyYAML>=5.3.1
 requests>=2.23.0
 scipy>=1.4.1
@@ -28,7 +27,7 @@ seaborn>=0.11.0
 # onnx>=1.9.0  # ONNX export
 # onnx-simplifier>=0.4.1  # ONNX simplifier
 # nvidia-pyindex  # TensorRT export
-nvidia-tensorrt==8.4.1.5  # TensorRT export
+# nvidia-tensorrt==8.4.1.5  # TensorRT export
 # scikit-learn<=1.1.2  # CoreML quantization
 # tensorflow>=2.4.1  # TF exports (-cpu, -aarch64, -macos)
 # tensorflowjs>=3.9.0  # TF.js export
@@ -38,10 +37,16 @@ nvidia-tensorrt==8.4.1.5  # TensorRT export
 # tritonclient[all]~=2.24.0
 
 # Extras --------------------------------------
-ipython  # interactive notebook
-psutil  # system utilization
-thop>=0.1.1  # FLOPs computation
+# ipython  # interactive notebook
+# psutil  # system utilization
+# thop>=0.1.1  # FLOPs computation
 # mss  # screenshots
 # albumentations>=1.0.3
 # pycocotools>=2.0  # COCO mAP
 # roboflow
+
+
+albumentations
+clearml
+# notebook
+Pillow>=9.1.0

--- a/utils/docker/Dockerfile
+++ b/utils/docker/Dockerfile
@@ -1,33 +1,28 @@
 # YOLOv5 🚀 by Ultralytics, GPL-3.0 license
-# Builds ultralytics/yolov5:latest image on DockerHub https://hub.docker.com/r/ultralytics/yolov5
-# Image is CUDA-optimized for YOLOv5 single/multi-GPU training and inference
 
-# Start FROM NVIDIA PyTorch image https://ngc.nvidia.com/catalog/containers/nvidia:pytorch
-FROM nvcr.io/nvidia/pytorch:22.09-py3
-RUN rm -rf /opt/pytorch  # remove 1.2GB dir
+FROM python:3.8-slim
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    TZ=Etc/UTC
+
 
 # Downloads to user config dir
 ADD https://ultralytics.com/assets/Arial.ttf https://ultralytics.com/assets/Arial.Unicode.ttf /root/.config/Ultralytics/
 
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && apt-get update -y && apt-get install google-cloud-sdk -y
 # Install linux packages
-RUN apt update && apt install --no-install-recommends -y zip htop screen libgl1-mesa-glx
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    libgl1-mesa-glx libglib2.0-0 curl git unzip &&\
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install aws
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip && rm -rf aws
+
+
 # Install pip packages
 COPY requirements.txt .
-RUN python -m pip install --upgrade pip wheel
-
-RUN pip install google-cloud-storage==1.29.0
-RUN pip install google-api-python-client==1.8.0
-
-ENV DEBIAN_FRONTEND noninteractive
-
-RUN pip uninstall -y torch torchvision torchtext Pillow
-RUN pip install --no-cache -r requirements.txt albumentations clearml wandb gsutil notebook Pillow>=9.1.0 \
-    'opencv-python<4.6.0.66' \
-    --extra-index-url https://download.pytorch.org/whl/cu113
+RUN pip install --no-cache -r requirements.txt
 
 # Create working directory
 RUN mkdir -p /usr/src/app
@@ -37,11 +32,6 @@ WORKDIR /usr/src/app
 # COPY . /usr/src/app  (issues as not a .git directory)
 RUN git clone https://github.com/voxel-ai/yolov5 /usr/src/app
 
-# Set environment variables
-ENV OMP_NUM_THREADS=8
-
-RUN apt-get -o Dpkg::Options::="--force-confmiss" install -y --no-install-recommends --reinstall netbase
-RUN apt-get update && apt-get install --no-install-recommends -y libgl1-mesa-glx libglib2.0-0
 ENTRYPOINT "/bin/bash"
 
 # Usage Examples -------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Updates the Yolov5 image requirements and removes `https://download.pytorch.org/whl/cu113` since we pip install cuda from our pypi requirements.

Tests:
- [x] Tested on yolo smoke test [here](https://sematic.voxelplatform.com/runs/cc12f8a059d643739bc26fab1fd776e3)